### PR TITLE
Align Kem with Internet draft while retaining those from editor's copy

### DIFF
--- a/src/kdf/common/config/oids.rs
+++ b/src/kdf/common/config/oids.rs
@@ -19,6 +19,7 @@ impl Oid for KdfType {
     fn get_oid(&self) -> String {
         match self {
             KdfType::HkdfWithSha256 => "1.2.840.113549.1.9.16.3.28",
+            KdfType::HkdfWithSha384 => "1.2.840.113549.1.9.16.3.29",
             KdfType::HkdfWithSha512 => "1.2.840.113549.1.9.16.3.30",
             KdfType::Kmac128 => "2.16.840.1.101.3.4.2.21",
             KdfType::Kmac256 => "2.16.840.1.101.3.4.2.22",

--- a/src/kdf/common/kdf_type.rs
+++ b/src/kdf/common/kdf_type.rs
@@ -8,6 +8,8 @@ pub enum KdfType {
     /// Hkdf with SHA-256
     HkdfWithSha256,
     /// Hkdf with SHA-512
+    HkdfWithSha384,
+    /// Hkdf with SHA-512
     HkdfWithSha512,
     /// Kmac with 128-bit key
     Kmac128,

--- a/src/kdf/hkdf.rs
+++ b/src/kdf/hkdf.rs
@@ -15,7 +15,9 @@ pub struct Hkdf {
 impl Kdf for Hkdf {
     fn new(kdf_type: KdfType) -> Result<Hkdf> {
         match kdf_type {
-            KdfType::HkdfWithSha256 | KdfType::HkdfWithSha512 => Ok(Hkdf { kdf_type }),
+            KdfType::HkdfWithSha256 | KdfType::HkdfWithSha512 | KdfType::HkdfWithSha384 => {
+                Ok(Hkdf { kdf_type })
+            }
             _ => Err(QuantCryptError::NotImplemented),
         }
     }
@@ -37,6 +39,13 @@ impl Kdf for Hkdf {
             }
             KdfType::HkdfWithSha512 => {
                 let prk = hkdf::Hkdf::<sha2::Sha512>::new(salt, ikm);
+                let mut okm: Vec<u8> = vec![0; length];
+                prk.expand(info, &mut okm)
+                    .map_err(|_| QuantCryptError::InvalidHkdfLength)?;
+                Ok(okm)
+            }
+            KdfType::HkdfWithSha384 => {
+                let prk = hkdf::Hkdf::<sha2::Sha384>::new(salt, ikm);
                 let mut okm: Vec<u8> = vec![0; length];
                 prk.expand(info, &mut okm)
                     .map_err(|_| QuantCryptError::InvalidHkdfLength)?;

--- a/src/kdf/kdf_manager.rs
+++ b/src/kdf/kdf_manager.rs
@@ -8,7 +8,11 @@ use crate::kdf::common::kdf_info::KdfInfo;
 
 type Result<T> = std::result::Result<T, QuantCryptError>;
 
-const HKDF_TYPES: [KdfType; 2] = [KdfType::HkdfWithSha256, KdfType::HkdfWithSha512];
+const HKDF_TYPES: [KdfType; 3] = [
+    KdfType::HkdfWithSha256,
+    KdfType::HkdfWithSha384,
+    KdfType::HkdfWithSha512,
+];
 const KMAC_TYPES: [KdfType; 2] = [KdfType::Kmac128, KdfType::Kmac256];
 
 // Implement clone

--- a/src/kem/api/algorithm.rs
+++ b/src/kem/api/algorithm.rs
@@ -10,6 +10,14 @@ pub enum KemAlgorithm {
     MlKem768,
     MlKem1024,
 
+    // The composite algorithm list from the old version
+    MlKem512P256,
+    MlKem512BrainpoolP256r1,
+    MlKem512X25519,
+    MlKem512Rsa2048,
+    MlKem512Rsa3072,
+    MlKem768P256,
+
     // The compsite algorithm list is from the latest editor's draft:
     //https://lamps-wg.github.io/draft-composite-kem/draft-ietf-lamps-pq-composite-kem.html
     MlKem768Rsa2048,
@@ -36,6 +44,14 @@ impl KemAlgorithm {
             KemAlgorithm::MlKem512 => KemType::MlKem512,
             KemAlgorithm::MlKem768 => KemType::MlKem768,
             KemAlgorithm::MlKem1024 => KemType::MlKem1024,
+
+            // The composite algorithm list from the old version
+            KemAlgorithm::MlKem512P256 => KemType::MlKem512P256,
+            KemAlgorithm::MlKem512BrainpoolP256r1 => KemType::MlKem512BrainpoolP256r1,
+            KemAlgorithm::MlKem512X25519 => KemType::MlKem512X25519,
+            KemAlgorithm::MlKem512Rsa2048 => KemType::MlKem512Rsa2048,
+            KemAlgorithm::MlKem512Rsa3072 => KemType::MlKem512Rsa3072,
+            KemAlgorithm::MlKem768P256 => KemType::MlKem768P256,
 
             // The compsite algorithm list is from the latest editor's draft:
             //https://lamps-wg.github.io/draft-composite-kem/draft-ietf-lamps-pq-composite-kem.html

--- a/src/kem/common/config/ct_len.rs
+++ b/src/kem/common/config/ct_len.rs
@@ -28,15 +28,29 @@ impl CTLen for KemType {
             KemType::MlKem768 => None,
             KemType::MlKem1024 => None,
             // Composite also varies as ML varies
-            KemType::MlKem768Rsa2048 => None,
-            KemType::MlKem768Rsa3072 => None,
-            KemType::MlKem768Rsa4096 => None,
-            KemType::MlKem768X25519 => None,
-            KemType::MlKem768P384 => None,
+            // Old version
+            KemType::MlKem512P256 => None,
+            KemType::MlKem512BrainpoolP256r1 => None,
+            KemType::MlKem512X25519 => None,
+            KemType::MlKem512Rsa2048 => None,
+            KemType::MlKem512Rsa3072 => None,
+            KemType::MlKem768P256 => None,
             KemType::MlKem768BrainpoolP256r1 => None,
+            KemType::MlKem768X25519 => None,
             KemType::MlKem1024P384 => None,
             KemType::MlKem1024BrainpoolP384r1 => None,
             KemType::MlKem1024X448 => None,
+            // Composite types from editor's draft. Skipped ones are also present in old version
+            // Editor's copy
+            KemType::MlKem768Rsa2048 => None,
+            KemType::MlKem768Rsa3072 => None,
+            KemType::MlKem768Rsa4096 => None,
+            // KemType::MlKem768X25519 => None,
+            KemType::MlKem768P384 => None,
+            // KemType::MlKem768BrainpoolP256r1 => None,
+            // KemType::MlKem1024P384 => None,
+            // KemType::MlKem1024BrainpoolP384r1 => None,
+            // KemType::MlKem1024X448 => None,
         }
     }
 }

--- a/src/kem/common/config/oids.rs
+++ b/src/kem/common/config/oids.rs
@@ -18,16 +18,30 @@ impl Oid for KemType {
     /// The OID for the KEM
     fn get_oid(&self) -> String {
         match self {
-            // Composite types:
+            // Composite types from old version:
+            KemType::MlKem512P256 => "2.16.840.1.114027.80.5.2.1.1",
+            KemType::MlKem512BrainpoolP256r1 => "2.16.840.1.114027.80.5.2.1.2",
+            KemType::MlKem512X25519 => "2.16.840.1.114027.80.5.2.1.3",
+            KemType::MlKem512Rsa2048 => "2.16.840.1.114027.80.5.2.1.13",
+            KemType::MlKem512Rsa3072 => "2.16.840.1.114027.80.5.2.1.4",
+            KemType::MlKem768P256 => "2.16.840.1.114027.80.5.2.1.5",
+            KemType::MlKem768BrainpoolP256r1 => "2.16.840.1.114027.80.5.2.1.6",
+            KemType::MlKem768X25519 => "2.16.840.1.114027.80.5.2.1.7",
+            KemType::MlKem1024P384 => "2.16.840.1.114027.80.5.2.1.8",
+            KemType::MlKem1024BrainpoolP384r1 => "2.16.840.1.114027.80.5.2.1.9",
+            KemType::MlKem1024X448 => "2.16.840.1.114027.80.5.2.1.10",
+
+            // Composite types from editor's copy, skipped ones are also in old version:
             KemType::MlKem768Rsa2048 => "2.16.840.1.114027.80.5.2.21",
             KemType::MlKem768Rsa3072 => "2.16.840.1.114027.80.5.2.22",
             KemType::MlKem768Rsa4096 => "2.16.840.1.114027.80.5.2.23",
-            KemType::MlKem768X25519 => "2.16.840.1.114027.80.5.2.24",
+            // KemType::MlKem768X25519 => "2.16.840.1.114027.80.5.2.24",
             KemType::MlKem768P384 => "2.16.840.1.114027.80.5.2.25",
-            KemType::MlKem768BrainpoolP256r1 => "2.16.840.1.114027.80.5.2.26",
-            KemType::MlKem1024P384 => "2.16.840.1.114027.80.5.2.27",
-            KemType::MlKem1024BrainpoolP384r1 => "2.16.840.1.114027.80.5.2.28",
-            KemType::MlKem1024X448 => "2.16.840.1.114027.80.5.2.29",
+            // KemType::MlKem768BrainpoolP256r1 => "2.16.840.1.114027.80.5.2.26",
+            // KemType::MlKem1024P384 => "2.16.840.1.114027.80.5.2.27",
+            // KemType::MlKem1024BrainpoolP384r1 => "2.16.840.1.114027.80.5.2.28",
+            // KemType::MlKem1024X448 => "2.16.840.1.114027.80.5.2.29",
+
             // EC Types:
             KemType::P256 => "1.2.840.10045.3.1.7",
             KemType::P384 => "1.3.132.0.34",

--- a/src/kem/common/config/pk_len.rs
+++ b/src/kem/common/config/pk_len.rs
@@ -29,17 +29,30 @@ impl PKLen for KemType {
             KemType::RsaOAEP2048 => None,
             KemType::RsaOAEP3072 => None,
             KemType::RsaOAEP4096 => None,
-            // Composite types
+            // Composite types from old version
+            // TODO: If there is a fixed size, then it should be added here
+            KemType::MlKem512P256 => None,
+            KemType::MlKem512BrainpoolP256r1 => None,
+            KemType::MlKem512X25519 => None,
+            KemType::MlKem512Rsa2048 => None,
+            KemType::MlKem512Rsa3072 => None,
+            KemType::MlKem768P256 => None,
+            KemType::MlKem768BrainpoolP256r1 => None,
+            KemType::MlKem768X25519 => None,
+            KemType::MlKem1024P384 => None,
+            KemType::MlKem1024BrainpoolP384r1 => None,
+            KemType::MlKem1024X448 => None,
+            // Composite types from editor's draft. Skipped ones are also present in old version
             // TODO: If there is a fixed size, then it should be added here
             KemType::MlKem768Rsa2048 => None,
             KemType::MlKem768Rsa3072 => None,
             KemType::MlKem768Rsa4096 => None,
-            KemType::MlKem768X25519 => None,
+            // KemType::MlKem768X25519 => None,
             KemType::MlKem768P384 => None,
-            KemType::MlKem768BrainpoolP256r1 => None,
-            KemType::MlKem1024P384 => None,
-            KemType::MlKem1024BrainpoolP384r1 => None,
-            KemType::MlKem1024X448 => None,
+            // KemType::MlKem768BrainpoolP256r1 => None,
+            // KemType::MlKem1024P384 => None,
+            // KemType::MlKem1024BrainpoolP384r1 => None,
+            // KemType::MlKem1024X448 => None,
         }
     }
 }

--- a/src/kem/common/config/sk_len.rs
+++ b/src/kem/common/config/sk_len.rs
@@ -35,17 +35,30 @@ impl SKLen for KemType {
             KemType::RsaOAEP2048 => None,
             KemType::RsaOAEP3072 => None,
             KemType::RsaOAEP4096 => None,
-            // Composite types
+            // Composite types from old version
+            // TODO: If there is a fixed size, then it should be added here
+            KemType::MlKem512P256 => None,
+            KemType::MlKem512BrainpoolP256r1 => None,
+            KemType::MlKem512X25519 => None,
+            KemType::MlKem512Rsa2048 => None,
+            KemType::MlKem512Rsa3072 => None,
+            KemType::MlKem768P256 => None,
+            KemType::MlKem768BrainpoolP256r1 => None,
+            KemType::MlKem768X25519 => None,
+            KemType::MlKem1024P384 => None,
+            KemType::MlKem1024BrainpoolP384r1 => None,
+            KemType::MlKem1024X448 => None,
+            // Composite types from editor's draft. Skipped ones are also present in old version
             // TODO: If there is a fixed size, then it should be added here
             KemType::MlKem768Rsa2048 => None,
             KemType::MlKem768Rsa3072 => None,
             KemType::MlKem768Rsa4096 => None,
-            KemType::MlKem768X25519 => None,
+            // KemType::MlKem768X25519 => None,
             KemType::MlKem768P384 => None,
-            KemType::MlKem768BrainpoolP256r1 => None,
-            KemType::MlKem1024P384 => None,
-            KemType::MlKem1024BrainpoolP384r1 => None,
-            KemType::MlKem1024X448 => None,
+            // KemType::MlKem768BrainpoolP256r1 => None,
+            // KemType::MlKem1024P384 => None,
+            // KemType::MlKem1024BrainpoolP384r1 => None,
+            // KemType::MlKem1024X448 => None,
         }
     }
 }

--- a/src/kem/common/config/ss_len.rs
+++ b/src/kem/common/config/ss_len.rs
@@ -35,16 +35,32 @@ impl SSLen for KemType {
             KemType::MlKem512 => 32,
             KemType::MlKem768 => 32,
             KemType::MlKem1024 => 32,
+
             // Composite types follow hash size
-            KemType::MlKem768Rsa2048 => 32,
-            KemType::MlKem768Rsa3072 => 32,
-            KemType::MlKem768Rsa4096 => 32,
-            KemType::MlKem768X25519 => 32,
-            KemType::MlKem768P384 => 48,
+            // Old version
+            KemType::MlKem512P256 => 32,
+            KemType::MlKem512BrainpoolP256r1 => 32,
+            KemType::MlKem512X25519 => 32,
+            KemType::MlKem512Rsa2048 => 32,
+            KemType::MlKem512Rsa3072 => 32,
+            KemType::MlKem768P256 => 48,
             KemType::MlKem768BrainpoolP256r1 => 48,
+            KemType::MlKem768X25519 => 48, // should be 48 given SHA3-384 in old version. In editor's copy it's SHA-256 and thus 32. Follow the public draft instead
             KemType::MlKem1024P384 => 64,
             KemType::MlKem1024BrainpoolP384r1 => 64,
             KemType::MlKem1024X448 => 64,
+
+            // Composite types from editor's draft. Skipped ones are also present in old version
+            // Editor's copy
+            KemType::MlKem768Rsa2048 => 32,
+            KemType::MlKem768Rsa3072 => 32,
+            KemType::MlKem768Rsa4096 => 32,
+            // KemType::MlKem768X25519 => 32,
+            KemType::MlKem768P384 => 48,
+            // KemType::MlKem768BrainpoolP256r1 => 48,
+            // KemType::MlKem1024P384 => 64,
+            // KemType::MlKem1024BrainpoolP384r1 => 64,
+            // KemType::MlKem1024X448 => 64,
         }
     }
 }

--- a/src/kem/common/kem_type.rs
+++ b/src/kem/common/kem_type.rs
@@ -30,6 +30,20 @@ pub enum KemType {
     /// MlKem1024 key encapsulation mechanism
     MlKem1024,
 
+    // The composite algorithm list from the old version
+    /// id-MLKEM512-ECDH-P256
+    MlKem512P256,
+    /// id-MLKEM512-ECDH-brainpoolP256r1
+    MlKem512BrainpoolP256r1,
+    /// id-MLKEM512-X25519
+    MlKem512X25519,
+    /// id-MLKEM512-RSA2048
+    MlKem512Rsa2048,
+    /// id-MLKEM512-RSA3072
+    MlKem512Rsa3072,
+    /// id-MLKEM768-ECDH-P256
+    MlKem768P256,
+
     // The compsite algorithm list is from the latest editor's draft:
     //https://lamps-wg.github.io/draft-composite-kem/draft-ietf-lamps-pq-composite-kem.html
     /// id-MLKEM768-RSA2048

--- a/src/kem/composite_kem.rs
+++ b/src/kem/composite_kem.rs
@@ -142,6 +142,45 @@ impl Kem for CompositeKemManager {
     fn new(kem_type: KemType) -> Result<Self> {
         let kem_info = KemInfo::new(kem_type.clone());
         let result = match kem_type {
+            // From old version
+            KemType::MlKem512P256 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::P256)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem512)?),
+                kdf: Kdf::new(KdfType::Sha3_256),
+            },
+            KemType::MlKem512BrainpoolP256r1 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::BrainpoolP256r1)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem512)?),
+                kdf: Kdf::new(KdfType::Sha3_256),
+            },
+            KemType::MlKem512X25519 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::X25519)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem512)?),
+                kdf: Kdf::new(KdfType::Sha3_256),
+            },
+            KemType::MlKem512Rsa2048 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::RsaOAEP2048)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem512)?),
+                kdf: Kdf::new(KdfType::Sha3_256),
+            },
+            KemType::MlKem512Rsa3072 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::RsaOAEP3072)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem512)?),
+                kdf: Kdf::new(KdfType::Sha3_256),
+            },
+            KemType::MlKem768P256 => Self {
+                kem_info,
+                trad_kem: Box::new(KemManager::new(KemType::P256)?),
+                pq_kem: Box::new(KemManager::new(KemType::MlKem768)?),
+                kdf: Kdf::new(KdfType::Sha3_384),
+            },
+
+            // From Editor's draft
             KemType::MlKem768Rsa2048 => Self {
                 kem_info,
                 trad_kem: Box::new(KemManager::new(KemType::RsaOAEP2048)?),
@@ -164,7 +203,8 @@ impl Kem for CompositeKemManager {
                 kem_info,
                 trad_kem: Box::new(KemManager::new(KemType::X25519)?),
                 pq_kem: Box::new(KemManager::new(KemType::MlKem768)?),
-                kdf: Kdf::new(KdfType::Sha3_256),
+                kdf: Kdf::new(KdfType::Sha3_384),
+                // kdf: Kdf::new(KdfType::Sha3_256),  //In editor's draft
             },
             KemType::MlKem768P384 => Self {
                 kem_info,
@@ -342,7 +382,44 @@ impl Kem for CompositeKemManager {
 mod tests {
     use super::*;
     use crate::kem::common::macros::test_kem;
+    // Tests for old version
+    #[test]
+    fn test_mlkem_512_p256() {
+        let kem = CompositeKemManager::new(KemType::MlKem512P256);
+        test_kem!(kem);
+    }
 
+    #[test]
+    fn test_mlkem_512_brainpool_p256_r1() {
+        let kem = CompositeKemManager::new(KemType::MlKem512BrainpoolP256r1);
+        test_kem!(kem);
+    }
+
+    #[test]
+    fn test_mlkem_512_x25519() {
+        let kem = CompositeKemManager::new(KemType::MlKem512X25519);
+        test_kem!(kem);
+    }
+
+    #[test]
+    fn test_mlkem_512_rsa2048() {
+        let kem = CompositeKemManager::new(KemType::MlKem512Rsa2048);
+        test_kem!(kem);
+    }
+
+    #[test]
+    fn test_mlkem_512_rsa3072() {
+        let kem = CompositeKemManager::new(KemType::MlKem512Rsa3072);
+        test_kem!(kem);
+    }
+
+    #[test]
+    fn test_mlkem_768_p256() {
+        let kem = CompositeKemManager::new(KemType::MlKem768P256);
+        test_kem!(kem);
+    }
+
+    // Tests for editor's copy
     #[test]
     fn test_mlkem_768_rsa2048() {
         let kem = CompositeKemManager::new(KemType::MlKem768Rsa2048);


### PR DESCRIPTION
This PR adds the ML-KEM types that are only available in the old draft than in the editor's copy. Namely:

MlKem512P256,
MlKem512BrainpoolP256r1,
MlKem512X25519,
MlKem512Rsa2048,
MlKem512Rsa3072,
MlKem768P256,