### PR TITLE
Update additional_info table for dsa and kem length

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "rust-analyzer.runnables.extraArgs": [
-        "--features=ipd"
+        
     ]
 }

--- a/additional_info_keysize.md
+++ b/additional_info_keysize.md
@@ -1,7 +1,9 @@
 
 # ML-DSA Key Length Summary
 
-| DSA | Traditional Algorithm  | Npk | Nsk | sig_len |
+Links to lengths in the project: [pk](src/dsa/common/config/pk_len.rs), [sk](src/dsa/common/config/sk_len.rs), [sig](src/dsa/common/config/sig_len.rs)
+
+| DSA | Traditional Algorithm  | Npk | Nsk | Nsig |
 | --- | -------------------- | --- | --- | ------- |
 | ML-DSA44 | <N.A> | 1312 | 2560 | 2420 |
 | ML-DSA44 | Rsa2048PssSha256 | 1596 | <N.A> | 2690 |
@@ -22,9 +24,9 @@
 
 ## ASCII Version
 ```
-+-----------+----------------------------+------+-------+----------+
-|   DSA     | Traditional Algorithm       | Npk  |  Nsk  | sig_len |
-+-----------+----------------------------+------+-------+---------+
++-----------+-----------------------------+------+-------+---------+
+|   DSA     | Traditional Algorithm       | Npk  |  Nsk  | Nsig    |
++-----------+-----------------------------+------+-------+---------+
 | ML-DSA44  | <N.A>                       | 1312 | 2560  | 2420    |
 | ML-DSA44  | Rsa2048PssSha256            | 1596 | <N.A> | 2690    |
 | ML-DSA44  | Rsa2048Pkcs15Sha256         | 1596 | <N.A> | 2690    |
@@ -46,7 +48,10 @@
 
 # ML-KEM Key Length Summary
 
-| KEM        | Traditional Composite    |   Npk | Nsk   |   ss_len |   ct_len |
+Links to lengths in the project: [pk](src/kem/common/config/pk_len.rs), [sk](src/kem/common/config/sk_len.rs), [ss](src/kem/common/config/ss_len.rs), [ct](src/kem/common/config/ct_len.rs)
+
+
+| KEM        | Traditional Composite    |   Npk | Nsk   |    Nss   |    Nct   |
 |------------|--------------------------|-------|-------|----------|----------|
 | ML-KEM512  | P256                     |   877 | 1782  |       32 |      843 |
 | ML-KEM512  | BrainpoolP256r1          |   877 | 1782  |       32 |      843 |
@@ -73,7 +78,7 @@
 ## ASCII Version
 ```
 +-----------+-----------------------+------+--------+--------+--------+
-| KEM       | Traditional Composite | Npk  | Nsk    | ss_len | ct_len |
+| KEM       | Traditional Composite | Npk  |   Nsk  |   Nss  |   Nct  |
 +-----------+-----------------------+------+--------+--------+--------+
 | ML-KEM512 | P256                  |  877 |  1782  |   32   |   843  |
 | ML-KEM512 | BrainpoolP256r1       |  877 |  1782  |   32   |   843  |
@@ -99,7 +104,10 @@
 
 ### Notes on Overhead Computation
 
-The full derivation of the aforementioned lengths can be found in the `common::config` folder of the DSA folder. As a general guideline, below are some overhead computations:
+The following computations illustrate the overhead of common structures in ASN.1:
+- **Overhead of a OCTET STRING** = Tag + Length.  
+    - Short-form length (<=127 bytes) => 1 + 1 = 2  
+    - Long-form length (> 127 bytes) => 1 + 3 = 4  
 
 - **Overhead of a BIT STRING** = Tag + Length + Unused Bits.  
     - Short-form length (<=127 bytes) => 1 + 1 + 1 = 3  
@@ -109,7 +117,7 @@ The full derivation of the aforementioned lengths can be found in the `common::c
     - Short-form length (<=127 bytes) => 1 + 1 = 2  
     - Long-form length (> 127 bytes) => 1 + 3 = 4  
 
-### PublicKey
+### PublicKey ([DSA](src/dsa/common/config/pk_len.rs), [KEM](src/kem/common/config/pk_len.rs))
 
 ```plaintext
 SEQUENCE {
@@ -122,7 +130,7 @@ Overhead of a SEQUENCE SIZE (2) OF BIT STRING (one short-form, one long form) = 
 
 Overhead of a SEQUENCE SIZE (2) OF BIT STRING (two long form) = 5 + 5 + 4 = 14 
 
-### SecretKey
+### SecretKey ([DSA](src/dsa/common/config/sk_len.rs), [KEM](src/kem/common/config/sk_len.rs))
 
 ```plaintext
 SEQUENCE {
@@ -131,7 +139,7 @@ SEQUENCE {
 }
 ```
 
-### OneAsymmetricKey
+#### OneAsymmetricKey
 
 ```plaintext
 SEQUENCE {
@@ -141,25 +149,25 @@ SEQUENCE {
 }
 ```
 
-Overhead of an OneAsymmetricKey (OAK) without a public key for a long private key:  
+#### Overhead of an OneAsymmetricKey (OAK) without a public key for a long private key:  
 
-- (outer sequence overhead => 1(tag) + 3(length in long form)) = 4  
+- (outer sequence overhead => 1(tag) + 3(long-form length)) = 4  
 - (private key => 1(tag) + 3(long-form length)) = 4  
-- (privateKeyAlgorithm => 1(tag) + <oid_bytes> + 2 (inner sequence, short_form length)) = 3 + <oid_bytes>  
+- (privateKeyAlgorithm => 1(tag) + <oid_bytes> + 2 (inner sequence, short-form length)) = 3 + <oid_bytes>  
 
 Total = 11 + <oid_bytes>
 
 For ML-KEM: `<oid_bytes> = 13`, so the overhead = 13 + 11 = 24
 
-### Overhead of an OneAsymmetricKey (OAK) without a public key for a short private key:
+#### Overhead of an OneAsymmetricKey (OAK) without a public key for a short private key:
 
-- (outer sequence overhead => 1(tag) + 3(length in long form)) = 4  
-- (private key => 1(tag) + 1(short-form length)) = 4  
-- (privateKeyAlgorithm => 1(tag) + <oid_bytes> + 2 (inner sequence, short_form length)) = 3 + <oid_bytes>  
+- (outer sequence overhead => 1(tag) + 3(long-form length)) = 4  
+- (private key => 1(tag) + 1(short-form length)) = 2  
+- (privateKeyAlgorithm => 1(tag) + <oid_bytes> + 2 (inner sequence, short-form length)) = 3 + <oid_bytes>  
 
 Total = 9 + <oid_bytes>
 
-### Calculation Results for varied `<oid_bytes>` in DSA Composites:
+#### Calculation Results for varied `<oid_bytes>` in DSA Composites:
 
 | Traditional Algorithm | Oid | Number of Bytes | Overhead |
 | --------------------- | --- | --------------- | -------- |
@@ -170,6 +178,24 @@ Total = 9 + <oid_bytes>
 | EcdsaP256SHA512 | 1.2.840.10045.4.3.4 | 10 | 9 + 10 = 19 |
 | EcdsaP384SHA512 | 1.2.840.10045.4.3.4 | 10 | 9 + 10 = 19 |
 
-### DSA vs KEM Secret Key Overhead Comparison
+#### DSA vs KEM Secret Key Overhead Comparison
 
 For the secret key of composite KEMs, they also store the public key of the tranditional algorithm, causing additional overheads. On the other hand, composite DSAs do not store traditional public keys so that their secret key overhead is solely due to the wrapping structures (Algorithm Identifier and SEQUENCE). 
+
+### CipherText Length ([KEM](src/kem/common/config/ct_len.rs))
+```plaintext
+SEQUENCE {
+    pq_ct   OCTET STRING,  
+    trad_ct OCTET STRING,
+}
+```
+As demonstrated in the [notes on overhead computation](#notes-on-overhead-computation) section, the overhead is either 10 or 12 for cipher text depending on the length of the keys: pq_tag (1) + pq_len(3, KEM is always long-form) + trad_tag (1) + trad_length(1 or 3) + Sequence(4).
+
+### Singature Length ([DSA](src/dsa/common/config/sig_len.rs))
+```plaintext
+SEQUENCE {
+    pq_sig BIT STRING,  
+    trad_sig BIT STRING,
+}
+```
+Similar structure to public key overhead computation: The value is either 12 or 14.

--- a/additional_info_keysize.md
+++ b/additional_info_keysize.md
@@ -1,22 +1,103 @@
 
 # ML-DSA Key Length Summary
 
-| DSA | Traditional Composite | Npk | Nsk | sig_len |
+| DSA | Traditional Algorithm  | Npk | Nsk | sig_len |
 | --- | -------------------- | --- | --- | ------- |
 | ML-DSA44 | <N.A> | 1312 | 2560 | 2420 |
-| ML-DSA44 | Ed25519SHA512 | 1356 | 2634 | 2690 |
-| ML-DSA44 | EcdsaP256SHA256 | 1389 | 2639 | 2690 |
-| ML-DSA44 | EcdsaBrainpoolP256r1SHA256 | 1389 | 2639 | 2496 |
+| ML-DSA44 | Rsa2048PssSha256 | 1596 | <N.A> | 2690 |
+| ML-DSA44 | Rsa2048Pkcs15Sha256 | 1596 | <N.A> | 2690 |
+| ML-DSA44 | Ed25519SHA512 | 1356 | 2634 | 2496 |
+| ML-DSA44 | EcdsaP256SHA256 | 1389 | 2639 | <N.A> |
+| ML-DSA44 | EcdsaBrainpoolP256r1SHA256 | 1389 | 2639 | <N.A> |
 | ML-DSA65 | <N.A> | 1952 | 4032 | 3309 |
-| ML-DSA65 | EcdsaP256SHA512 | 2029 | 4111 | 3707 |
-| ML-DSA65 | EcdsaBrainpoolP256r1SHA512 | 2029 | 4111 | 3707 |
+| ML-DSA65 | Rsa3072PssSHA512 | 2364 | <N.A> | 3707 |
+| ML-DSA65 | Rsa3072Pkcs15SHA512 | 2364 | <N.A> | 3707 |
+| ML-DSA65 | EcdsaP256SHA512 | 2029 | 4111 | <N.A> |
+| ML-DSA65 | EcdsaBrainpoolP256r1SHA512 | 2029 | 4111 | <N.A> |
 | ML-DSA65 | Ed25519SHA512 | 1996 | 4106 | 3385 |
 | ML-DSA87 | <N.A> | 2592 | 4896 | 4627 |
 | ML-DSA87 | EcdsaP384SHA512 | 2701 | 4991 | <N.A> |
 | ML-DSA87 | EcdsaBrainpoolP384r1SHA512 | 2701 | 4991 | <N.A> |
 | ML-DSA87 | Ed448SHA512 | 2661 | 4995 | 4753 |
 
-## Notes on Overhead Computation
+## ASCII Version
+```
++-----------+----------------------------+------+-------+----------+
+|   DSA     | Traditional Algorithm       | Npk  |  Nsk  | sig_len |
++-----------+----------------------------+------+-------+---------+
+| ML-DSA44  | <N.A>                       | 1312 | 2560  | 2420    |
+| ML-DSA44  | Rsa2048PssSha256            | 1596 | <N.A> | 2690    |
+| ML-DSA44  | Rsa2048Pkcs15Sha256         | 1596 | <N.A> | 2690    |
+| ML-DSA44  | Ed25519SHA512               | 1356 | 2634  | 2496    |
+| ML-DSA44  | EcdsaP256SHA256             | 1389 | 2639  | <N.A>   |
+| ML-DSA44  | EcdsaBrainpoolP256r1SHA256  | 1389 | 2639  | <N.A>   |
+| ML-DSA65  | <N.A>                       | 1952 | 4032  | 3309    |
+| ML-DSA65  | Rsa3072PssSHA512            | 2364 | <N.A> | 3707    |
+| ML-DSA65  | Rsa3072Pkcs15SHA512         | 2364 | <N.A> | 3707    |
+| ML-DSA65  | EcdsaP256SHA512             | 2029 | 4111  | <N.A>   |
+| ML-DSA65  | EcdsaBrainpoolP256r1SHA512  | 2029 | 4111  | <N.A>   |
+| ML-DSA65  | Ed25519SHA512               | 1996 | 4106  | 3385    |
+| ML-DSA87  | <N.A>                       | 2592 | 4896  | 4627    |
+| ML-DSA87  | EcdsaP384SHA512             | 2701 | 4991  | <N.A>   |
+| ML-DSA87  | EcdsaBrainpoolP384r1SHA512  | 2701 | 4991  | <N.A>   |
+| ML-DSA87  | Ed448SHA512                 | 2661 | 4995  | 4753    |
++-----------+----------------------------+------+-------+----------+
+```
+
+# ML-KEM Key Length Summary
+
+| KEM        | Traditional Composite    |   Npk | Nsk   |   ss_len |   ct_len |
+|------------|--------------------------|-------|-------|----------|----------|
+| ML-KEM512  | P256                     |   877 | 1782  |       32 |      843 |
+| ML-KEM512  | BrainpoolP256r1          |   877 | 1782  |       32 |      843 |
+| ML-KEM512  | X25519                   |   844 | 1749  |       32 |      810 |
+| ML-KEM512  | Rsa2048                  |  1084 | <N.A> |       32 |     1036 |
+| ML-KEM512  | Rsa3072                  |  1084 | <N.A> |       32 |     1164 |
+| ML-KEM768  | P256                     |  1261 | 2550  |       48 |     1163 |
+| ML-KEM768  | BrainpoolP256r1          |  1261 | 2550  |       48 |     1163 |
+| ML-KEM768  | X25519                   |  1228 | 2517  |     **48 |  ***1130 |
+| *ML-KEM768 | Rsa2048                  |  1468 | <N.A> |       32 |     1356 |
+| *ML-KEM768 | Rsa3072                  |  1596 | <N.A> |       32 |     1484 |
+| *ML-KEM768 | Rsa4096                  |  1724 | <N.A> |       32 |     1612 |
+| *ML-KEM768 | P384                     |  1293 | 2599  |       48 |     1195 |
+| ML-KEM1024 | P384                     |  1677 | 3367  |       64 |     1675 |
+| ML-KEM1024 | BrainpoolP384r1          |  1677 | 3367  |       64 |     1675 |
+| ML-KEM1024 | X448                     |  1636 | 3334  |       64 |     1634 |
+
+*: Only available in editor’s copy  
+
+**: 48 given SHA3-384 in the public version. In the editor's copy it's SHA-256 and thus 32. Following the public version [here](https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/04/).
+
+*** Here the computation (kem_ct + trad_ct + overhead) = 1088 + 32 + 10 = 1130, and the composite computation logic seems to follow the editor’s copy (i.e. SHA-256 instead of SHA3-384).
+
+## ASCII Version
+```
++-----------+-----------------------+------+--------+--------+--------+
+| KEM       | Traditional Composite | Npk  | Nsk    | ss_len | ct_len |
++-----------+-----------------------+------+--------+--------+--------+
+| ML-KEM512 | P256                  |  877 |  1782  |   32   |   843  |
+| ML-KEM512 | BrainpoolP256r1       |  877 |  1782  |   32   |   843  |
+| ML-KEM512 | X25519                |  844 |  1749  |   32   |   810  |
+| ML-KEM512 | Rsa2048               | 1084 |  N/A   |   32   |  1036  |
+| ML-KEM512 | Rsa3072               | 1084 |  N/A   |   32   |  1164  |
+| ML-KEM768 | P256                  | 1261 |  2550  |   48   |  1163  |
+| ML-KEM768 | BrainpoolP256r1       | 1261 |  2550  |   48   |  1163  |
+| ML-KEM768 | X25519                | 1228 |  2517  | **48   | ***1130|
+| *ML-KEM768| Rsa2048               | 1468 |  N/A   |   32   |  1356  |
+| *ML-KEM768| Rsa3072               | 1596 |  N/A   |   32   |  1484  |
+| *ML-KEM768| Rsa4096               | 1724 |  N/A   |   32   |  1612  |
+| *ML-KEM768| P384                  | 1293 |  2599  |   48   |  1195  |
+| ML-KEM1024| P384                  | 1677 |  3367  |   64   |  1675  |
+| ML-KEM1024| BrainpoolP384r1       | 1677 |  3367  |   64   |  1675  |
+| ML-KEM1024| X448                  | 1636 |  3334  |   64   |  1634  |
++-----------+-----------------------+------+--------+--------+--------+
+
+*: Only available in editor’s copy  
+**: Should be 48 given SHA3-384 in the public version. In the editor's copy it's SHA-256 and thus 32. Following the public version [here](https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/04/).
+*** Here the computation (kem_ct + trad_ct + overhead) = 1088 + 32 + 10 = 1130, and the composite computation logic seems to follow the editor’s copy (i.e. SHA-256 instead of SHA3-384).
+```
+
+### Notes on Overhead Computation
 
 The full derivation of the aforementioned lengths can be found in the `common::config` folder of the DSA folder. As a general guideline, below are some overhead computations:
 
@@ -88,3 +169,7 @@ Total = 9 + <oid_bytes>
 | EcdsaBrainpoolP384r1SHA512 | 1.2.840.10045.4.3.4 | 10 | 9 + 10 = 19 |
 | EcdsaP256SHA512 | 1.2.840.10045.4.3.4 | 10 | 9 + 10 = 19 |
 | EcdsaP384SHA512 | 1.2.840.10045.4.3.4 | 10 | 9 + 10 = 19 |
+
+### DSA vs KEM Secret Key Overhead Comparison
+
+For the secret key of composite KEMs, they also store the public key of the tranditional algorithm, causing additional overheads. On the other hand, composite DSAs do not store traditional public keys so that their secret key overhead is solely due to the wrapping structures (Algorithm Identifier and SEQUENCE). 

--- a/src/dsa/common/config/pk_len.rs
+++ b/src/dsa/common/config/pk_len.rs
@@ -13,10 +13,10 @@ impl PKLen for DsaType {
     /// The length of the public key in bytes or `None` if the length is not fixed
     fn get_pk_len(&self) -> Option<usize> {
         match self {
-            DsaType::Rsa2048Pkcs15SHA256 => None,
-            DsaType::Rsa2048PssSHA256 => None,
-            DsaType::Rsa3072Pkcs15SHA512 => None,
-            DsaType::Rsa3072PssSHA512 => None,
+            DsaType::Rsa2048Pkcs15SHA256 => Some(270),
+            DsaType::Rsa2048PssSHA256 => Some(270),
+            DsaType::Rsa3072Pkcs15SHA512 => Some(398),
+            DsaType::Rsa3072PssSHA512 => Some(398),
 
             DsaType::EcdsaP256SHA256 => Some(65),
             DsaType::EcdsaP256SHA512 => Some(65),
@@ -32,13 +32,13 @@ impl PKLen for DsaType {
             DsaType::MlDsa87 => Some(2592),
 
             // pq_pk + trad_pk + overhead
-            DsaType::MlDsa44Rsa2048PssSha256 => None,
-            DsaType::MlDsa44Rsa2048Pkcs15Sha256 => None,
+            DsaType::MlDsa44Rsa2048PssSha256 => Some(1312 + 270 + 14),
+            DsaType::MlDsa44Rsa2048Pkcs15Sha256 => Some(1312 + 270 + 14),
             DsaType::MlDsa44Ed25519SHA512 => Some(1312 + 32 + 12),
             DsaType::MlDsa44EcdsaP256SHA256 => Some(1312 + 65 + 12),
             DsaType::MlDsa44EcdsaBrainpoolP256r1SHA256 => Some(1312 + 65 + 12),
-            DsaType::MlDsa65Rsa3072PssSHA512 => None,
-            DsaType::MlDsa65Rsa3072Pkcs15SHA512 => None,
+            DsaType::MlDsa65Rsa3072PssSHA512 => Some(1952 + 398 + 14),
+            DsaType::MlDsa65Rsa3072Pkcs15SHA512 => Some(1952 + 398 + 14),
             DsaType::MlDsa65EcdsaP256SHA512 => Some(1952 + 65 + 12),
             DsaType::MlDsa65EcdsaBrainpoolP256r1SHA512 => Some(1952 + 65 + 12),
             DsaType::MlDsa65Ed25519SHA512 => Some(1952 + 32 + 12),

--- a/src/dsa/common/config/sig_len.rs
+++ b/src/dsa/common/config/sig_len.rs
@@ -18,6 +18,7 @@ impl SigLen for DsaType {
             DsaType::Rsa3072Pkcs15SHA512 => Some(384),
             DsaType::Rsa3072PssSHA512 => Some(384),
 
+            // P256 and P384 variations do not have a fixed sig_len
             DsaType::EcdsaP256SHA256 => None,
             DsaType::EcdsaP256SHA512 => None,
             DsaType::EcdsaP384SHA512 => None,

--- a/src/dsa/common/config/sk_len.rs
+++ b/src/dsa/common/config/sk_len.rs
@@ -13,6 +13,7 @@ impl SKLen for DsaType {
     /// The length of the private key in bytes or `None` if the length is not fixed
     fn get_sk_len(&self) -> Option<usize> {
         match self {
+            // RSAs do not have a fixed sk length
             DsaType::Rsa2048Pkcs15SHA256 => None,
             DsaType::Rsa2048PssSHA256 => None,
             DsaType::Rsa3072Pkcs15SHA512 => None,

--- a/src/kem/common/config/sk_len.rs
+++ b/src/kem/common/config/sk_len.rs
@@ -36,7 +36,9 @@ impl SKLen for KemType {
             KemType::RsaOAEP3072 => None,
             KemType::RsaOAEP4096 => None,
             // Composite types from old version
+            // In Kem composites, traditional public key is part of the private key
             // pq_sk + trad_sk + pq_overhead + trad_public_key_overhead + trad_overhead + sequence_overhead
+            // trad_overhead = 9 + <oid_byte>
             KemType::MlKem512P256 => Some(1632 + 32 + 24 + (65 + 6) + 19 + 4),
             KemType::MlKem512BrainpoolP256r1 => Some(1632 + 32 + 24 + (65 + 6) + 19 + 4),
             KemType::MlKem512X25519 => Some(1632 + 32 + 24 + (32 + 11) + 14 + 4),
@@ -49,7 +51,6 @@ impl SKLen for KemType {
             KemType::MlKem1024BrainpoolP384r1 => Some(3168 + 48 + 24 + (97 + 7) + 19 + 4),
             KemType::MlKem1024X448 => Some(3168 + 56 + 24 + (56 + 12) + 14 + 4),
             // Composite types from editor's draft. Skipped ones are also present in old version
-            // KEM Sk + Trad Sk + ASN.1 overhead
             KemType::MlKem768Rsa2048 => None,
             KemType::MlKem768Rsa3072 => None,
             KemType::MlKem768Rsa4096 => None,

--- a/src/kem/common/config/ss_len.rs
+++ b/src/kem/common/config/ss_len.rs
@@ -45,7 +45,9 @@ impl SSLen for KemType {
             KemType::MlKem512Rsa3072 => 32,
             KemType::MlKem768P256 => 48,
             KemType::MlKem768BrainpoolP256r1 => 48,
-            KemType::MlKem768X25519 => 48, // should be 48 given SHA3-384 in old version. In editor's copy it's SHA-256 and thus 32. Follow the public draft instead
+            // Should be 48 given SHA3-384 in the public version. In the editor's copy it's SHA-256 and thus 32. Follow the public version here.
+            // Public Copy Reference: https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/
+            KemType::MlKem768X25519 => 48,
             KemType::MlKem1024P384 => 64,
             KemType::MlKem1024BrainpoolP384r1 => 64,
             KemType::MlKem1024X448 => 64,


### PR DESCRIPTION
This PR contains the following changes:
- Fix the DSA table by adding in the RSA composites, and remove incorrect sig_len assigned to P256 and its variants;
- Add pk_len computation for RSA variants in CompositeDSA
- Upload table for key length in composite KEMs 